### PR TITLE
Support running all tests with pytest, make --no-mmlibs --no-undo the default

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import pymol
+
+pymol.__path__.append(".")
+pymol.__path__.append("tests/helpers")
+
+collect_ignore = [
+    "tests/helpers",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,8 @@
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning
+addopts =
+    --import-mode=importlib
+testpaths = tests
+python_files =
+    *.py

--- a/testing.py
+++ b/testing.py
@@ -377,8 +377,6 @@ else:
             assertEquals = unittest.TestCase.assertEqual
             assertItemsEqual = unittest.TestCase.assertCountEqual
 
-        moddirs = {}
-
         def setUp(self):
             self.oldcwd = os.getcwd()
             cmd.reinitialize()
@@ -387,7 +385,7 @@ else:
             if cliargs.no_undo:
                 cmd.set('suspend_undo', updates=0)
 
-            cwd = self.moddirs[type(self).__module__]
+            cwd = os.path.dirname(inspect.getfile(type(self)))
             os.chdir(cwd)
 
             cmd.feedback('push')
@@ -679,7 +677,6 @@ USAGE
 
             # hacky: register working directory with test cases
             dirname = os.path.abspath(os.path.dirname(filename))
-            PyMOLTestCase.moddirs[mod.__name__] = dirname
 
             suite.addTest(unittest.defaultTestLoader
                     .loadTestsFromModule(mod))

--- a/testing.py
+++ b/testing.py
@@ -104,8 +104,10 @@ else:
     parser.add_argument('filenames', nargs='*', default=[])
     parser.add_argument('--out', default=sys.stdout)
     parser.add_argument('--offline', action='store_true')
-    parser.add_argument('--no-mmlibs', action='store_true')
-    parser.add_argument('--no-undo', action='store_true')
+    parser.add_argument('--no-mmlibs', action='store_true', default=True)
+    parser.add_argument('--with-mmlibs', action='store_false', dest='no_mmlibs')
+    parser.add_argument('--no-undo', action='store_true', default=True)
+    parser.add_argument('--with-undo', action='store_false', dest='no_undo')
     parser.add_argument('--verbosity', type=int, default=2)
 
     have_dash_dash = __file__.startswith(sys.argv[0]) or '--run' in sys.argv

--- a/tests/api/importing.py
+++ b/tests/api/importing.py
@@ -529,7 +529,7 @@ class TestImporting(testing.PyMOLTestCase):
                 0.21, -0.644, -0.644]
         self.assertArrayEqual(charges, charges_expected, delta=1e-4)
 
-    @testing.requires_version('1.8.3.1')
+    @testing.requires_version('2.6')
     def testLoadPLY(self):
         cmd.load(self.datafile("test_PHE_pentamer.ply.gz"))
         e = cmd.get_extent('test_PHE_pentamer')


### PR DESCRIPTION
Supports running all tests with:
```sh
python -m pytest
```
Result with latest pymol-open-source:
```
====== 654 passed, 331 skipped, 1 warning in 40.53s ======
```
Result with incentive pymol 2.5.6:
```
====== 767 passed, 218 skipped, 1 warning in 43.11s ======
```

Because `mmlibs` and `undo` tests are [not supported by PyMOL 2.5](https://github.com/schrodinger/pymol-testing/issues/9), I disabled them by default.